### PR TITLE
fix: remove unsupported graph section from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,11 +1,5 @@
 # cargo-deny configuration for bitcoin-augur
 
-[graph]
-# All features on crates.io is equivalent to:
-# * `--no-default-features --features foo` for each feature `foo` defined for a crate on crates.io
-# * `--all-features` if no features are defined for a crate on crates.io
-all-features = true
-
 [licenses]
 # Confidence threshold for detecting license files
 confidence-threshold = 0.9


### PR DESCRIPTION
Fixes CI Dependency License Check failure

## Problem
The Dependency License Check is failing because cargo-deny 0.14.3 doesn't support the `[graph]` section in deny.toml.

## Solution
Remove the unsupported `[graph]` section from deny.toml, keeping only valid sections.

## Test Plan
- [x] Tested locally with `cargo deny check`
- [ ] CI checks should pass after this fix