### PR TITLE
feat: use BTreeMap for sorted JSON keys in API responses

### DIFF
--- a/bitcoin-augur-server/src/api/models.rs
+++ b/bitcoin-augur-server/src/api/models.rs
@@ -1,7 +1,7 @@
 use bitcoin_augur::{BlockTarget, FeeEstimate};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Response format for fee estimation API matching Kotlin implementation
 #[derive(Debug, Serialize, Deserialize)]
@@ -11,14 +11,14 @@ pub struct FeeEstimateResponse {
     pub mempool_update_time: String,
 
     /// Map of block targets to their probability estimates
-    pub estimates: HashMap<String, BlockTargetResponse>,
+    pub estimates: BTreeMap<String, BlockTargetResponse>,
 }
 
 /// Block target with probability-based fee estimates
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlockTargetResponse {
     /// Map of probability percentages to fee rates
-    pub probabilities: HashMap<String, ProbabilityResponse>,
+    pub probabilities: BTreeMap<String, ProbabilityResponse>,
 }
 
 /// Fee rate for a specific probability
@@ -48,7 +48,7 @@ pub fn transform_fee_estimate(estimate: FeeEstimate) -> FeeEstimateResponse {
 }
 
 /// Transform internal BlockTarget to API format
-fn transform_block_target(target: BlockTarget) -> HashMap<String, ProbabilityResponse> {
+fn transform_block_target(target: BlockTarget) -> BTreeMap<String, ProbabilityResponse> {
     target
         .probabilities
         .into_iter()
@@ -82,7 +82,7 @@ fn format_timestamp(timestamp: DateTime<Utc>) -> String {
 pub fn empty_response(timestamp: DateTime<Utc>) -> FeeEstimateResponse {
     FeeEstimateResponse {
         mempool_update_time: format_timestamp(timestamp),
-        estimates: HashMap::new(),
+        estimates: BTreeMap::new(),
     }
 }
 


### PR DESCRIPTION
## Summary
Replace HashMap with BTreeMap in API response models to ensure JSON keys are always sorted for consistent and predictable output.

## Problem
The API responses had unsorted keys in the JSON output, making it harder to read and less predictable:
```json
{
  "probabilities": {
    "0.05": { "fee_rate": 1.0 },
    "0.80": { "fee_rate": 1.0105 },
    "0.20": { "fee_rate": 1.0 },
    "0.95": { "fee_rate": 2.034 },
    "0.50": { "fee_rate": 1.0 }
  }
}
```

## Solution
Using `BTreeMap` instead of `HashMap` ensures keys are always sorted:
```json
{
  "probabilities": {
    "0.05": { "fee_rate": 1.0 },
    "0.20": { "fee_rate": 1.0 },
    "0.50": { "fee_rate": 1.0 },
    "0.80": { "fee_rate": 1.0105 },
    "0.95": { "fee_rate": 2.034 }
  }
}
```

## Changes
- Replace `HashMap` with `BTreeMap` in `FeeEstimateResponse.estimates`
- Replace `HashMap` with `BTreeMap` in `BlockTargetResponse.probabilities`
- Update `transform_block_target` return type to `BTreeMap`
- Update `empty_response` to use `BTreeMap::new()`

## Benefits
- Consistent JSON output across all API responses
- Easier to read and parse
- Better for testing and debugging
- No performance impact (BTreeMap is efficient for small collections)

## Testing
- [x] All existing tests pass
- [x] Manual testing confirms sorted keys
- [x] Regression tests continue to pass