### PR TITLE
chore: update dependencies and add Dependabot configuration

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -21,22 +21,35 @@ if command -v nix >/dev/null 2>&1 && [ -f "flake.nix" ]; then
     
     # Run clippy
     echo "🔎 Running clippy linting..."
-    if ! nix develop -c cargo clippy --all-targets -- -D warnings 2>&1; then
+    if ! nix develop -c cargo clippy --all-targets --all-features -- -D warnings 2>&1; then
         echo ""
         echo "❌ Clippy found issues. Please fix them before pushing."
         echo ""
         echo "To see all issues:"
-        echo "  nix develop -c cargo clippy --all-targets"
+        echo "  nix develop -c cargo clippy --all-targets --all-features"
         echo ""
         echo "To attempt automatic fixes:"
-        echo "  nix develop -c cargo clippy --all-targets --fix --allow-dirty"
+        echo "  nix develop -c cargo clippy --all-targets --all-features --fix --allow-dirty"
         exit 1
     fi
     echo "✅ Clippy check passed"
     echo ""
     
-    # Note: Tests are run in CI, not in pre-push hook to avoid blocking pushes
-    echo "ℹ️  Tests will be run in CI pipeline"
+    # Check for outdated dependencies (warning only)
+    echo "📦 Checking for outdated dependencies..."
+    if ! nix develop -c cargo outdated --exit-code 1 --root-deps-only 2>/dev/null; then
+        echo ""
+        echo "⚠️  Warning: Outdated dependencies detected:"
+        nix develop -c cargo outdated --root-deps-only 2>/dev/null | head -30
+        echo ""
+        echo "To update compatible versions:"
+        echo "  nix develop -c cargo upgrade"
+        echo ""
+        echo "For incompatible updates (major versions), review changelog and update manually."
+        echo "Consider updating dependencies when appropriate."
+    else
+        echo "✅ All dependencies are up to date"
+    fi
 else
     # Fallback to regular cargo
     echo "📝 Checking code formatting..."
@@ -53,22 +66,40 @@ else
     
     # Run clippy
     echo "🔎 Running clippy linting..."
-    if ! cargo clippy --all-targets -- -D warnings 2>&1; then
+    if ! cargo clippy --all-targets --all-features -- -D warnings 2>&1; then
         echo ""
         echo "❌ Clippy found issues. Please fix them before pushing."
         echo ""
         echo "To see all issues:"
-        echo "  cargo clippy --all-targets"
+        echo "  cargo clippy --all-targets --all-features"
         echo ""
         echo "To attempt automatic fixes:"
-        echo "  cargo clippy --all-targets --fix --allow-dirty"
+        echo "  cargo clippy --all-targets --all-features --fix --allow-dirty"
         exit 1
     fi
     echo "✅ Clippy check passed"
     echo ""
     
-    # Note: Tests are run in CI, not in pre-push hook to avoid blocking pushes
-    echo "ℹ️  Tests will be run in CI pipeline"
+    # Check for outdated dependencies (non-nix fallback, warning only)
+    echo "📦 Checking for outdated dependencies..."
+    if command -v cargo-outdated >/dev/null 2>&1; then
+        if ! cargo outdated --exit-code 1 --root-deps-only 2>/dev/null; then
+            echo ""
+            echo "⚠️  Warning: Outdated dependencies detected:"
+            cargo outdated --root-deps-only 2>/dev/null | head -30
+            echo ""
+            echo "To update compatible versions:"
+            echo "  cargo upgrade"
+            echo ""
+            echo "For incompatible updates (major versions), review changelog and update manually."
+            echo "Consider updating dependencies when appropriate."
+        else
+            echo "✅ All dependencies are up to date"
+        fi
+    else
+        echo "⚠️  cargo-outdated not found. Skipping dependency check."
+        echo "   Install with: cargo install cargo-outdated"
+    fi
 fi
 
 echo ""

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  # Enable version updates for Rust dependencies (Cargo)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+    open-pull-requests-limit: 10
+    groups:
+      patch-and-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    reviewers:
+      - "douglaz"
+    assignees:
+      - "douglaz"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    reviewers:
+      - "douglaz"
+    assignees:
+      - "douglaz"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1001,7 +1001,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.3+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1181,7 +1181,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1492,11 +1492,11 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -1634,12 +1634,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1741,12 +1740,6 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1890,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -1939,7 +1932,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1953,9 +1946,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1964,7 +1957,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -1973,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
@@ -1994,16 +1987,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2147,47 +2140,32 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
@@ -2555,16 +2533,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -2755,7 +2723,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -2938,14 +2906,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -3088,11 +3056,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3218,22 +3186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,12 +3193,6 @@ checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
  "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3568,13 +3514,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ndarray = { version = "0.16", features = ["serde"] }
 statrs = "0.17"
 
 # Async runtime
-tokio = { version = "1.42", features = ["full"] }
+tokio = { version = "1.47", features = ["full"] }
 
 # HTTP and networking
 axum = { version = "0.7", features = ["macros"] }
@@ -41,7 +41,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Testing
-proptest = "1.6"
+proptest = "1.7"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # For static builds

--- a/bitcoin-augur-regression-tests/Cargo.toml
+++ b/bitcoin-augur-regression-tests/Cargo.toml
@@ -32,14 +32,14 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 # Utilities
-tempfile = "3.14"
+tempfile = "3.21"
 which = "7.0"
 colored = "2.2"
 chrono = { workspace = true }
 
 # For floating point comparison
 float-cmp = "0.10"
-ordered-float = "4.5"
+ordered-float = "4.6"
 
 # For concurrent tests
 futures = "0.3"

--- a/bitcoin-augur-server/Cargo.toml
+++ b/bitcoin-augur-server/Cargo.toml
@@ -63,11 +63,11 @@ base64 = "0.22"
 [dev-dependencies]
 # Mocking
 faux = "0.1"
-mockito = "1.2"
+mockito = "1.7"
 wiremock = "0.6"
 
 # Test utilities
-tempfile = "3.8"
+tempfile = "3.21"
 tower = { workspace = true }
-serial_test = "3.1"
+serial_test = "3.2"
 pretty_assertions = "1.4"

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755830208,
-        "narHash": "sha256-fMa/Hcg+4O2h+kl3gNPjtGSWPI8NtCl3LYMsejK6qGA=",
+        "lastModified": 1756521112,
+        "narHash": "sha256-/YW9DI+vZ2lbTvYAek6BsudUXdpWr0FybTDod4P42L4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "802a7b97f8ff672ba2dec70c9e354f51f844e796",
+        "rev": "2243e3f251ea18486f83133cf8e325d2b9b71e89",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
                 git config core.hooksPath .githooks
                 echo "✅ Git hooks configured automatically!"
                 echo "   • pre-commit: Checks code formatting"
-                echo "   • pre-push: Runs formatting, clippy, and tests"
+                echo "   • pre-push: Runs formatting, clippy, and checks for outdated dependencies"
                 echo ""
                 echo "To disable: git config --unset core.hooksPath"
                 echo ""


### PR DESCRIPTION
## Summary
This PR updates project dependencies and adds Dependabot configuration for automated dependency management.

## Changes

### 📦 Dependency Updates
- **Rust dependencies updated to latest compatible versions:**
  - `tokio`: 1.42 → 1.47
  - `proptest`: 1.6 → 1.7  
  - `tempfile`: 3.14/3.8 → 3.21
  - `mockito`: 1.2 → 1.7
  - `serial_test`: 3.1 → 3.2
  - Various transitive dependency updates

- **Nix flake inputs updated:**
  - `nixpkgs`: Updated to latest (2025-08-30)
  - `rust-overlay`: Updated to latest (2025-08-30)

### 🤖 Dependabot Configuration
- Added `.github/dependabot.yml` for automated dependency updates
- Configured weekly checks for:
  - Cargo dependencies (grouped by patch/minor versions)
  - GitHub Actions
- Proper labeling and commit message prefixes configured

### 🪝 Enhanced Git Hooks
- Updated pre-push hook from cyberkrill project
- Added outdated dependency checking (warning only)
- Improved feedback and suggestions for developers
- Updated flake.nix shellHook description

## Test Plan
- [x] All tests pass (`cargo test --workspace`)
- [x] No clippy warnings (`cargo clippy --workspace`)
- [x] Code formatting verified (`cargo fmt --check`)
- [x] Git hooks tested and working
- [x] Nix flake builds successfully

## Breaking Changes
None - all updates are to compatible versions.