### PR TITLE
feat: add Nix-based GitHub Container Registry publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,12 +15,12 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: docker.io
+  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
-    name: Build with Nix and Push to Docker Hub
+    name: Build with Nix and Push to GitHub Container Registry
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,13 +58,13 @@ jobs:
           docker load < ${{ env.NIX_DOCKER_IMAGE }}
           docker images bitcoin-augur-server
       
-      - name: Log in to Docker Hub
+      - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Extract metadata
         id: meta
@@ -99,16 +99,6 @@ jobs:
             docker push "$tag"
           done
       
-      - name: Push README to Docker Hub
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
-        uses: peter-evans/dockerhub-description@v4
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ github.repository }}
-          readme-filepath: ./README.md
-          short-description: "Bitcoin Augur - Statistical Bitcoin fee estimation service"
-
   test-image:
     name: Test Docker Image
     needs: build-and-push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,149 @@
+name: Docker Build and Push
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - 'release/**'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build with Nix and Push to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Setup Nix cache
+        if: github.event_name != 'pull_request'
+        uses: cachix/cachix-action@v15
+        with:
+          name: bitcoin-augur
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: false
+      
+      - name: Build Docker image with Nix
+        run: |
+          echo "Building Docker image with Nix..."
+          nix build .#docker -L
+          echo "NIX_DOCKER_IMAGE=$(readlink -f result)" >> $GITHUB_ENV
+      
+      - name: Load Docker image
+        run: |
+          echo "Loading Docker image from Nix build..."
+          docker load < ${{ env.NIX_DOCKER_IMAGE }}
+          docker images bitcoin-augur-server
+      
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Default tags
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            # Latest tag for master branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            # Git SHA
+            type=sha,prefix={{branch}}-,format=short
+            # Date-based tag  
+            type=raw,value={{date 'YYYYMMDD'}},enable={{is_default_branch}}
+      
+      - name: Tag and push Docker image
+        if: github.event_name != 'pull_request'
+        run: |
+          # Parse tags from metadata
+          TAGS="${{ steps.meta.outputs.tags }}"
+          
+          # Tag and push each tag
+          echo "$TAGS" | while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "Tagging as $tag"
+            docker tag bitcoin-augur-server:latest "$tag"
+            docker push "$tag"
+          done
+      
+      - name: Push README to Docker Hub
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ github.repository }}
+          readme-filepath: ./README.md
+          short-description: "Bitcoin Augur - Statistical Bitcoin fee estimation service"
+
+  test-image:
+    name: Test Docker Image
+    needs: build-and-push
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Test published image
+        run: |
+          # Pull the image we just pushed
+          docker pull ${{ env.REGISTRY }}/${{ github.repository }}:latest
+          
+          # Test basic functionality
+          echo "Testing --version flag..."
+          docker run --rm ${{ env.REGISTRY }}/${{ github.repository }}:latest --version
+          
+          echo "Testing --help flag..."
+          docker run --rm ${{ env.REGISTRY }}/${{ github.repository }}:latest --help
+          
+          # Test running the server
+          echo "Starting server..."
+          docker run -d --name test-server \
+            -p 8080:8080 \
+            ${{ env.REGISTRY }}/${{ github.repository }}:latest
+          
+          # Wait for server to start
+          sleep 10
+          
+          # Test endpoints
+          echo "Testing /health endpoint..."
+          curl -f http://localhost:8080/health || (docker logs test-server && exit 1)
+          
+          echo "Testing /fees/1 endpoint..."
+          curl -f http://localhost:8080/fees/1 || (docker logs test-server && exit 1)
+          
+          # Clean up
+          docker stop test-server
+          docker rm test-server

--- a/flake.nix
+++ b/flake.nix
@@ -145,7 +145,9 @@
           bitcoin-augur-server = bitcoin-augur; # Alias for CI compatibility
           
           # Docker image with static binary and debugging tools
-          docker = pkgs.dockerTools.buildImage {
+          docker = let
+            second = 1000000000; # 1 second in nanoseconds
+          in pkgs.dockerTools.buildImage {
             name = "bitcoin-augur-server";
             tag = "latest";
             
@@ -197,9 +199,9 @@
               };
               Healthcheck = {
                 Test = [ "CMD" "${pkgs.curl}/bin/curl" "-f" "http://localhost:8080/health" ];
-                Interval = 30000000000; # 30 seconds in nanoseconds
-                Timeout = 3000000000;   # 3 seconds in nanoseconds
-                StartPeriod = 10000000000; # 10 seconds in nanoseconds
+                Interval = 30 * second; # 30 seconds
+                Timeout = 3 * second;   # 3 seconds
+                StartPeriod = 10 * second; # 10 seconds
                 Retries = 3;
               };
             };

--- a/flake.nix
+++ b/flake.nix
@@ -180,7 +180,8 @@
             };
             
             config = {
-              Cmd = [ "/bin/bitcoin-augur-server" ];
+              Entrypoint = [ "/bin/bitcoin-augur-server" ];
+              Cmd = [];
               Env = [
                 "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
                 "SYSTEM_CERTIFICATE_PATH=${pkgs.cacert}/etc/ssl/certs"

--- a/flake.nix
+++ b/flake.nix
@@ -144,21 +144,63 @@
           default = bitcoin-augur;
           bitcoin-augur-server = bitcoin-augur; # Alias for CI compatibility
           
-          # Docker image with static binary
+          # Docker image with static binary and debugging tools
           docker = pkgs.dockerTools.buildImage {
             name = "bitcoin-augur-server";
             tag = "latest";
             
             copyToRoot = pkgs.buildEnv {
               name = "image-root";
-              paths = [ bitcoin-augur ];
-              pathsToLink = [ "/bin" ];
+              paths = [ 
+                bitcoin-augur
+                pkgs.bashInteractive
+                pkgs.coreutils
+                pkgs.curl
+                pkgs.cacert
+                pkgs.bitcoind
+                pkgs.jq
+                pkgs.netcat
+                pkgs.procps
+                pkgs.htop
+                pkgs.vim
+                pkgs.less
+                pkgs.gnugrep
+                pkgs.gawk
+                pkgs.gnused
+                pkgs.findutils
+                pkgs.which
+                pkgs.net-tools
+                pkgs.iputils
+                pkgs.dnsutils
+                pkgs.gnutar
+              ];
+              pathsToLink = [ "/bin" "/etc" "/share" ];
             };
             
             config = {
               Cmd = [ "/bin/bitcoin-augur-server" ];
+              Env = [
+                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                "SYSTEM_CERTIFICATE_PATH=${pkgs.cacert}/etc/ssl/certs"
+                "RUST_LOG=info"
+              ];
               ExposedPorts = {
                 "8080/tcp" = {};
+              };
+              WorkingDir = "/";
+              Labels = {
+                "org.opencontainers.image.title" = "Bitcoin Augur Server";
+                "org.opencontainers.image.description" = "Statistical Bitcoin fee estimation service";
+                "org.opencontainers.image.vendor" = "Bitcoin Augur";
+                "org.opencontainers.image.source" = "https://github.com/${self.owner or "bitcoin-augur"}/${self.repo or "bitcoin-augur-rust"}";
+                "org.opencontainers.image.documentation" = "https://github.com/${self.owner or "bitcoin-augur"}/${self.repo or "bitcoin-augur-rust"}#readme";
+              };
+              Healthcheck = {
+                Test = [ "CMD" "${pkgs.curl}/bin/curl" "-f" "http://localhost:8080/health" ];
+                Interval = 30000000000; # 30 seconds in nanoseconds
+                Timeout = 3000000000;   # 3 seconds in nanoseconds
+                StartPeriod = 10000000000; # 10 seconds in nanoseconds
+                Retries = 3;
               };
             };
           };


### PR DESCRIPTION
## Summary
This PR adds automated Docker image publishing to GitHub Container Registry (ghcr.io) using Nix-based builds.

## Changes
- Added GitHub Actions workflow for Docker publishing on every commit to master
- Configured Nix-based Docker image building with comprehensive debugging tools
- Implemented multi-tag strategy (latest, version tags, SHA, date)
- Enhanced flake.nix Docker configuration with health checks and metadata
- Fixed Docker Entrypoint configuration to properly handle CLI arguments

## Key Features
- **GitHub Container Registry**: Uses ghcr.io instead of Docker Hub
- **No external secrets needed**: Uses built-in GITHUB_TOKEN for authentication
- **Nix-only approach**: No Dockerfile needed, builds directly from flake.nix
- **Debugging tools included**: bash, curl, bitcoin-cli, jq, htop, vim, tar, and more
- **Health checks**: Built-in health check endpoint monitoring
- **Readable time values**: Uses `30 * second` syntax instead of raw nanoseconds

## Docker Image Access
Once merged, images will be available at:
```
ghcr.io/douglaz/bitcoin-augur-rust:latest
```

## Test Plan
- [x] Tested Docker image build locally with `nix build .#docker`
- [x] Verified --version and --help flags work correctly
- [x] Confirmed health check endpoint works
- [x] Validated GitHub Actions workflow syntax
- [x] Tested with debugging tools included

## Benefits over Docker Hub
- Free for public repositories
- No additional secrets configuration required
- Better integration with GitHub repository
- Automatic linking of images to repository
- Same visibility as repository (public repo = public images)