### PR TITLE
fix: Docker entrypoint to handle CLI arguments correctly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -181,7 +181,8 @@
             };
             
             config = {
-              Cmd = [ "/bin/bitcoin-augur-server" ];
+              Entrypoint = [ "/bin/bitcoin-augur-server" ];
+              Cmd = [];
               Env = [
                 "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
                 "SYSTEM_CERTIFICATE_PATH=${pkgs.cacert}/etc/ssl/certs"


### PR DESCRIPTION
## Summary
Fixes Docker container to properly handle CLI arguments like `--version` and `--help`.

## Problem
The Docker test workflow was failing with:
```
error during container init: exec: "--version": executable file not found in /home/master/bin:/run/wrappers/bin:/home/master/.local/share/flatpak/exports/bin:/var/lib/flatpak/exports/bin:/home/master/.nix-profile/bin:/nix/profile/bin:/home/master/.local/state/nix/profile/bin:/etc/profiles/per-user/master/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin
```

## Root Cause
Using `Cmd` in the Docker config meant that additional arguments replaced the entire command instead of being passed to the binary.

## Solution
Changed from `Cmd` to `Entrypoint` in flake.nix, which properly passes arguments to the binary.

## Test
```bash
# Now works correctly:
docker run ghcr.io/douglaz/bitcoin-augur-rust:latest --version
# Output: bitcoin-augur-server 0.1.0

docker run ghcr.io/douglaz/bitcoin-augur-rust:latest --help
# Output: Shows help text
```

## References
- Fixes CI failure: https://github.com/douglaz/bitcoin-augur-rust/actions/runs/17363450198