### PR TITLE
fix: reduce Docker image size by 84% (2.4GB → 379MB)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,11 @@
           targets = [ "x86_64-unknown-linux-musl" ];
         };
 
+        # Minimal toolchain for building (no docs, analyzer, or src)
+        rustToolchainMinimal = pkgs.rust-bin.stable.latest.minimal.override {
+          targets = [ "x86_64-unknown-linux-musl" ];
+        };
+
       in
       {
         devShells.default = pkgs.mkShell {
@@ -86,8 +91,8 @@
         packages = rec {
           bitcoin-augur = let
             rustPlatformMusl = pkgs.makeRustPlatform {
-              cargo = rustToolchain;
-              rustc = rustToolchain;
+              cargo = rustToolchainMinimal;
+              rustc = rustToolchainMinimal;
             };
           in rustPlatformMusl.buildRustPackage {
             pname = "bitcoin-augur";
@@ -98,7 +103,7 @@
             
             nativeBuildInputs = with pkgs; [
               pkg-config
-              rustToolchain
+              rustToolchainMinimal
               pkgsStatic.stdenv.cc
             ];
             


### PR DESCRIPTION
## Summary
Dramatically reduces Docker image size by removing the entire Rust development toolchain from the runtime image.

## Problem
The Docker image was **2.42GB** when it should be under 400MB. Investigation revealed that the entire Rust development toolchain was being included:
- Rust documentation: 707MB
- Rust compiler: 373MB  
- Rust default toolchain: 383MB
- Rust std libraries: 372MB
- GCC compiler: 249MB

## Solution
Created a minimal Rust toolchain specifically for building production binaries:
- Added `rustToolchainMinimal` without docs, rust-analyzer, or rust-src
- Use minimal toolchain for building the `bitcoin-augur` package
- Keep full toolchain for development environment

## Results
- **Before**: 2.42GB
- **After**: 379MB
- **Reduction**: 84% (saved 2.04GB)

## Testing
- [x] Docker image builds successfully
- [x] Binary runs correctly (`--version` and `--help` work)
- [x] No Rust toolchain packages in the runtime image
- [x] Development environment still has full toolchain

## Future Optimizations
The remaining 379MB includes debugging tools that could be further optimized:
- bitcoind: 56MB
- vim: 48MB
- systemd: 43MB

These could be removed or made optional in a future PR if a minimal production image is desired.