### PR TITLE
fix(ci): correct API endpoint path in Docker test

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -157,8 +157,8 @@ jobs:
           echo "Testing /health endpoint..."
           curl -f http://localhost:8080/health || (echo "Health check failed"; docker logs test-server; exit 1)
           
-          echo "Testing /fees/1 endpoint..."
-          curl -f http://localhost:8080/fees/1 || (echo "Fees endpoint failed"; docker logs test-server; exit 1)
+          echo "Testing /fees/target/1 endpoint..."
+          curl -f http://localhost:8080/fees/target/1 || (echo "Fees endpoint failed"; docker logs test-server; exit 1)
           
           echo "Testing /fees endpoint..."
           curl -f http://localhost:8080/fees || (echo "Fees endpoint failed"; docker logs test-server; exit 1)


### PR DESCRIPTION
## Summary
Fixes the Docker test that was failing due to incorrect API endpoint path.

## Problem
The test was using  but the actual API endpoint is .

## Solution
Changed the endpoint to match the correct format: 

## Evidence
Server logs clearly show the correct endpoint format:
```
GET /fees/target/{num_blocks} - Fee estimates for specific target
```

## Test Plan
- [x] Corrected endpoint path
- [ ] CI tests should pass with proper endpoint

This simple fix should resolve the remaining Docker test failure.