### PR TITLE
fix(ci): use minimum 3 blocks for fee estimation API

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -157,8 +157,8 @@ jobs:
           echo "Testing /health endpoint..."
           curl -f http://localhost:8080/health || (echo "Health check failed"; docker logs test-server; exit 1)
           
-          echo "Testing /fees/target/1 endpoint..."
-          curl -f http://localhost:8080/fees/target/1 || (echo "Fees endpoint failed"; docker logs test-server; exit 1)
+          echo "Testing /fees/target/3 endpoint..."
+          curl -f http://localhost:8080/fees/target/3 || (echo "Fees endpoint failed"; docker logs test-server; exit 1)
           
           echo "Testing /fees endpoint..."
           curl -f http://localhost:8080/fees || (echo "Fees endpoint failed"; docker logs test-server; exit 1)


### PR DESCRIPTION
## Summary
The Docker test is failing because the API requires a minimum of 3 blocks for fee estimation.

## Problem
- Test was using `/fees/target/1` 
- API returns 400 Bad Request for targets less than 3 blocks
- This causes the Docker test to fail in CI

## Solution
Changed the test to use `/fees/target/3` which meets the minimum requirement.

## Test Plan
- [x] Updated endpoint to use valid block target
- [ ] CI tests should pass with this change